### PR TITLE
Add weekly heatmap and category colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,10 +12,16 @@
     <h2>Add Entry</h2>
     <form id="entry-form">
       <label>Category: <input type="text" id="category" required></label>
+      <label>Color: <input type="color" id="color" value="#ff0000"></label>
       <label>Date: <input type="date" id="date" required></label>
       <label>Hours: <input type="number" id="hours" step="0.1" min="0" required></label>
       <button type="submit">Add</button>
     </form>
+  </section>
+
+  <section id="heatmap-section">
+    <h2>Weekly Category Heatmap</h2>
+    <table id="heatmap"></table>
   </section>
 
   <section>

--- a/script.js
+++ b/script.js
@@ -1,6 +1,7 @@
 (() => {
   const form = document.getElementById('entry-form');
   const categoryInput = document.getElementById('category');
+  const colorInput = document.getElementById('color');
   const dateInput = document.getElementById('date');
   const hoursInput = document.getElementById('hours');
   const chartTypeSelect = document.getElementById('chart-type');
@@ -8,13 +9,59 @@
   const endDateInput = document.getElementById('end-date');
   const showChartBtn = document.getElementById('show-chart');
   const ctx = document.getElementById('chart').getContext('2d');
+  const heatmapTable = document.getElementById('heatmap');
 
   let chart;
   let entries = JSON.parse(localStorage.getItem('entries') || '[]');
+  let categoryColors = JSON.parse(localStorage.getItem('categoryColors') || '{}');
+
+  function saveColors() {
+    localStorage.setItem('categoryColors', JSON.stringify(categoryColors));
+  }
 
   function saveEntries() {
     localStorage.setItem('entries', JSON.stringify(entries));
   }
+
+  function renderHeatmap() {
+    const now = new Date();
+    const days = [];
+    for (let i = 6; i >= 0; i--) {
+      const d = new Date(now);
+      d.setDate(now.getDate() - i);
+      days.push(d);
+    }
+    const keys = days.map(d => d.toISOString().slice(0, 10));
+    const totals = {};
+    entries.forEach(e => {
+      if (keys.includes(e.date)) {
+        totals[e.category] = totals[e.category] || {};
+        totals[e.category][e.date] = (totals[e.category][e.date] || 0) + e.hours;
+      }
+    });
+
+    const weeklyTotals = {};
+    Object.keys(totals).forEach(cat => {
+      weeklyTotals[cat] = keys.reduce((sum, k) => sum + (totals[cat][k] || 0), 0);
+    });
+    const sorted = Object.keys(weeklyTotals).sort((a, b) => weeklyTotals[b] - weeklyTotals[a]);
+
+    let html = '<tr><th>Category</th>' +
+      keys.map(k => '<th>' + new Date(k).toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) + '</th>').join('') +
+      '</tr>';
+    sorted.forEach(cat => {
+      html += '<tr><td>' + cat + '</td>';
+      keys.forEach(k => {
+        const val = totals[cat] && totals[cat][k] ? totals[cat][k].toFixed(1) : '0';
+        html += '<td>' + val + '</td>';
+      });
+      html += '</tr>';
+    });
+    heatmapTable.innerHTML = html;
+  }
+
+  // initial render
+  renderHeatmap();
 
   form.addEventListener('submit', e => {
     e.preventDefault();
@@ -24,9 +71,14 @@
       hours: parseFloat(hoursInput.value)
     };
     if (entry.category && entry.date && !isNaN(entry.hours)) {
+      if (!categoryColors[entry.category]) {
+        categoryColors[entry.category] = colorInput.value || '#888888';
+        saveColors();
+      }
       entries.push(entry);
       saveEntries();
       form.reset();
+      renderHeatmap();
     }
   });
 
@@ -57,8 +109,8 @@
         datasets: [{
           label: 'Hours',
           data,
-          backgroundColor: 'rgba(75, 192, 192, 0.2)',
-          borderColor: 'rgba(75, 192, 192, 1)',
+          backgroundColor: labels.map(l => categoryColors[l] || 'rgba(75, 192, 192, 0.2)'),
+          borderColor: labels.map(l => categoryColors[l] || 'rgba(75, 192, 192, 1)'),
           borderWidth: 1,
           fill: type === 'line' ? false : true,
         }]
@@ -72,4 +124,10 @@
   }
 
   showChartBtn.addEventListener('click', renderChart);
+
+  window.addEventListener('storage', () => {
+    entries = JSON.parse(localStorage.getItem('entries') || '[]');
+    categoryColors = JSON.parse(localStorage.getItem('categoryColors') || '{}');
+    renderHeatmap();
+  });
 })();

--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,12 @@
 body { font-family: Arial, sans-serif; margin: 20px; }
 form label { margin-right: 10px; }
 section { margin-bottom: 30px; }
+
+#heatmap-section table { border-collapse: collapse; width: 100%; }
+#heatmap-section th, #heatmap-section td {
+  border: 1px solid #ccc;
+  padding: 4px;
+  background: #f9f9f9;
+  font-weight: bold;
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- add color picker when entering a category
- show a weekly heatmap with totals per category
- store category colors in localStorage
- use category colors in all charts
- style heatmap table

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6883d695d940832282db76dbc9615338