### PR TITLE
Add timeline filters and Excel export

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <title>Time Tracker</title>
   <link rel="stylesheet" href="styles.css">
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
 </head>
 <body>
   <h1>Time Tracker</h1>
@@ -20,7 +21,15 @@
   </section>
 
   <section id="heatmap-section">
-    <h2>Weekly Category Heatmap</h2>
+    <h2>Category Overview</h2>
+    <label>View:
+      <select id="time-range">
+        <option value="week">Week</option>
+        <option value="month">Month</option>
+        <option value="year">Year</option>
+      </select>
+    </label>
+    <button id="export-excel">Export to Excel</button>
     <table id="heatmap"></table>
   </section>
 

--- a/script.js
+++ b/script.js
@@ -10,6 +10,8 @@
   const showChartBtn = document.getElementById('show-chart');
   const ctx = document.getElementById('chart').getContext('2d');
   const heatmapTable = document.getElementById('heatmap');
+  const rangeSelect = document.getElementById('time-range');
+  const exportBtn = document.getElementById('export-excel');
 
   let chart;
   let entries = JSON.parse(localStorage.getItem('entries') || '[]');
@@ -23,7 +25,7 @@
     localStorage.setItem('entries', JSON.stringify(entries));
   }
 
-  function renderHeatmap() {
+  function renderWeekHeatmap() {
     const now = new Date();
     const days = [];
     for (let i = 6; i >= 0; i--) {
@@ -53,15 +55,167 @@
       html += '<tr><td>' + cat + '</td>';
       keys.forEach(k => {
         const val = totals[cat] && totals[cat][k] ? totals[cat][k].toFixed(1) : '0';
-        html += '<td>' + val + '</td>';
+        html += '<td data-cat="' + cat + '" data-date="' + k + '">' + val + '</td>';
       });
       html += '</tr>';
     });
     heatmapTable.innerHTML = html;
+    heatmapTable.querySelectorAll('td[data-cat]').forEach(td => {
+      td.addEventListener('click', () => {
+        const cat = td.dataset.cat;
+        const date = td.dataset.date;
+        const current = parseFloat(td.textContent) || 0;
+        const val = prompt('Hours', current);
+        if (val === null) return;
+        const hours = parseFloat(val);
+        if (!isNaN(hours)) {
+          entries = entries.filter(e => !(e.category === cat && e.date === date));
+          if (hours > 0) entries.push({ category: cat, date, hours });
+          saveEntries();
+          td.classList.add('edited');
+          setTimeout(() => td.classList.remove('edited'), 800);
+          renderView();
+        }
+      });
+    });
+  }
+
+  function renderMonthChart() {
+    const now = new Date();
+    const start = new Date(now.getFullYear(), now.getMonth(), 1);
+    const daysInMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
+    const labels = [];
+    const data = [];
+    for (let i = 1; i <= daysInMonth; i++) {
+      const d = new Date(start);
+      d.setDate(i);
+      const key = d.toISOString().slice(0, 10);
+      labels.push(i.toString());
+      data.push(entries.filter(e => e.date === key).reduce((s, e) => s + e.hours, 0));
+    }
+    if (chart) chart.destroy();
+    chart = new Chart(ctx, {
+      type: 'bar',
+      data: { labels, datasets: [{ label: 'Hours', data, backgroundColor: '#69c' }] },
+      options: { scales: { y: { beginAtZero: true } } }
+    });
+    heatmapTable.innerHTML = '';
+  }
+
+  function renderYearChart() {
+    const now = new Date();
+    const months = Array.from({ length: 12 }, (_, i) => new Date(now.getFullYear(), i, 1));
+    const labels = months.map(m => m.toLocaleDateString(undefined, { month: 'short' }));
+    const cats = [...new Set(entries.map(e => e.category))];
+    const datasets = cats.map(cat => {
+      const data = months.map(m => {
+        const monthStr = m.toISOString().slice(0, 7);
+        return entries
+          .filter(e => e.category === cat && e.date.startsWith(monthStr))
+          .reduce((s, e) => s + e.hours, 0);
+      });
+      return {
+        label: cat,
+        data,
+        borderColor: categoryColors[cat] || '#000',
+        backgroundColor: categoryColors[cat] || 'rgba(0,0,0,0.1)',
+        fill: false
+      };
+    });
+    if (chart) chart.destroy();
+    chart = new Chart(ctx, {
+      type: 'line',
+      data: { labels, datasets },
+      options: { scales: { y: { beginAtZero: true } } }
+    });
+    heatmapTable.innerHTML = '';
+  }
+
+  function exportToExcel() {
+    const wb = XLSX.utils.book_new();
+
+    const entrySheet = XLSX.utils.json_to_sheet(entries.map(e => ({
+      Category: e.category,
+      Hours: e.hours,
+      Date: e.date,
+      Color: categoryColors[e.category] || ''
+    })));
+    XLSX.utils.book_append_sheet(wb, entrySheet, 'Entries');
+
+    // weekly summary
+    const now = new Date();
+    const weekKeys = [];
+    for (let i = 6; i >= 0; i--) {
+      const d = new Date(now);
+      d.setDate(now.getDate() - i);
+      weekKeys.push(d.toISOString().slice(0, 10));
+    }
+    const weekHeader = ['Category'].concat(weekKeys.map(k => new Date(k).toLocaleDateString()));
+    const cats = [...new Set(entries.map(e => e.category))];
+    const weekData = [weekHeader];
+    cats.forEach(cat => {
+      const row = [cat];
+      weekKeys.forEach(k => {
+        const total = entries.filter(e => e.category === cat && e.date === k).reduce((s, e) => s + e.hours, 0);
+        row.push(total);
+      });
+      weekData.push(row);
+    });
+    const weekSheet = XLSX.utils.aoa_to_sheet(weekData);
+    XLSX.utils.book_append_sheet(wb, weekSheet, 'Weekly Summary');
+
+    // monthly summary
+    const start = new Date(now.getFullYear(), now.getMonth(), 1);
+    const daysInMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
+    const monthKeys = Array.from({ length: daysInMonth }, (_, i) => {
+      const d = new Date(start);
+      d.setDate(i + 1);
+      return d.toISOString().slice(0, 10);
+    });
+    const monthHeader = ['Category'].concat(monthKeys.map(k => k.slice(8)));
+    const monthData = [monthHeader];
+    cats.forEach(cat => {
+      const row = [cat];
+      monthKeys.forEach(k => {
+        const total = entries.filter(e => e.category === cat && e.date === k).reduce((s, e) => s + e.hours, 0);
+        row.push(total);
+      });
+      monthData.push(row);
+    });
+    const monthSheet = XLSX.utils.aoa_to_sheet(monthData);
+    XLSX.utils.book_append_sheet(wb, monthSheet, 'Monthly Summary');
+
+    // yearly summary
+    const months = Array.from({ length: 12 }, (_, i) => new Date(now.getFullYear(), i, 1));
+    const yearHeader = ['Category'].concat(months.map(m => m.toLocaleDateString(undefined, { month: 'short' })));
+    const yearData = [yearHeader];
+    cats.forEach(cat => {
+      const row = [cat];
+      months.forEach(m => {
+        const prefix = m.toISOString().slice(0, 7);
+        const total = entries.filter(e => e.category === cat && e.date.startsWith(prefix)).reduce((s, e) => s + e.hours, 0);
+        row.push(total);
+      });
+      yearData.push(row);
+    });
+    const yearSheet = XLSX.utils.aoa_to_sheet(yearData);
+    XLSX.utils.book_append_sheet(wb, yearSheet, 'Yearly Summary');
+
+    XLSX.writeFile(wb, 'time-tracking-export.xlsx');
+  }
+
+  function renderView() {
+    if (rangeSelect.value === 'month') {
+      renderMonthChart();
+    } else if (rangeSelect.value === 'year') {
+      renderYearChart();
+    } else {
+      renderWeekHeatmap();
+    }
   }
 
   // initial render
-  renderHeatmap();
+  renderView();
 
   form.addEventListener('submit', e => {
     e.preventDefault();
@@ -78,7 +232,7 @@
       entries.push(entry);
       saveEntries();
       form.reset();
-      renderHeatmap();
+      renderView();
     }
   });
 
@@ -124,10 +278,12 @@
   }
 
   showChartBtn.addEventListener('click', renderChart);
+  rangeSelect.addEventListener('change', renderView);
+  exportBtn.addEventListener('click', exportToExcel);
 
   window.addEventListener('storage', () => {
     entries = JSON.parse(localStorage.getItem('entries') || '[]');
     categoryColors = JSON.parse(localStorage.getItem('categoryColors') || '{}');
-    renderHeatmap();
+    renderView();
   });
 })();

--- a/styles.css
+++ b/styles.css
@@ -10,3 +10,7 @@ section { margin-bottom: 30px; }
   font-weight: bold;
   text-align: center;
 }
+#heatmap-section td.edited {
+  background: yellow;
+  transition: background-color 0.5s;
+}


### PR DESCRIPTION
## Summary
- make weekly heatmap editable
- add time range selector and export button
- draw month and year charts
- support Excel export with summaries

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6883db1d1cdc8322974e19d334413398