### PR TITLE
Improve monthly calendar layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -84,12 +84,32 @@
     const start = new Date(now.getFullYear(), now.getMonth(), 1);
     const daysInMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
     calendarEl.innerHTML = '';
+
+    const dows = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+    dows.forEach(dow => {
+      const h = document.createElement('div');
+      h.className = 'day-header';
+      h.textContent = dow;
+      calendarEl.appendChild(h);
+    });
+
+    const startOffset = (start.getDay() + 6) % 7;
+    for (let i = 0; i < startOffset; i++) {
+      const empty = document.createElement('div');
+      empty.className = 'day empty';
+      calendarEl.appendChild(empty);
+    }
+
     for (let i = 1; i <= daysInMonth; i++) {
       const d = new Date(start);
       d.setDate(i);
       const key = d.toISOString().slice(0, 10);
       const cell = document.createElement('div');
       cell.className = 'day';
+      const dowSpan = document.createElement('span');
+      dowSpan.className = 'dow';
+      dowSpan.textContent = d.toLocaleDateString(undefined, { weekday: 'short' });
+      cell.appendChild(dowSpan);
       const dateSpan = document.createElement('span');
       dateSpan.className = 'date';
       dateSpan.textContent = i;
@@ -126,6 +146,13 @@
         tooltipEl.style.display = 'none';
       });
       calendarEl.appendChild(cell);
+    }
+
+    const endBlanks = (7 - ((startOffset + daysInMonth) % 7)) % 7;
+    for (let i = 0; i < endBlanks; i++) {
+      const empty = document.createElement('div');
+      empty.className = 'day empty';
+      calendarEl.appendChild(empty);
     }
     if (overviewChart) {
       overviewChart.destroy();

--- a/styles.css
+++ b/styles.css
@@ -17,12 +17,30 @@ section { margin-bottom: 30px; }
   grid-template-columns: repeat(7, 1fr);
   gap: 2px;
 }
+#calendar .day-header {
+  text-align: center;
+  font-weight: bold;
+  background: #eee;
+  padding: 2px 0;
+  font-size: 12px;
+}
 #calendar .day {
   border: 1px solid #ccc;
   height: 80px;
   position: relative;
   background: #f9f9f9;
   font-size: 12px;
+}
+#calendar .day.empty {
+  border: none;
+  background: transparent;
+}
+#calendar .day .dow {
+  position: absolute;
+  top: 2px;
+  right: 4px;
+  font-size: 10px;
+  color: #555;
 }
 #calendar .date {
   position: absolute;


### PR DESCRIPTION
## Summary
- add weekday headers and row padding for month view
- display day-of-week label inside each day cell
- style headers and weekday labels

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6887b3d748b8832286f04d440c6a894e