### PR TITLE
Add goal tracker panel and persistent categories

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
     <div id="tooltip" class="tooltip"></div>
   </section>
 
-  <section>
+  <section id="chart-section">
     <h2>View Chart</h2>
     <label>Chart Type:
       <select id="chart-type">
@@ -61,7 +61,18 @@
       <label><input type="checkbox" value="6" checked>Sat</label>
     </div>
     <button id="show-chart">Show Chart</button>
-    <canvas id="chart" width="400" height="200"></canvas>
+    <div id="chart-goal-container">
+      <div id="chart-container">
+        <canvas id="chart" width="400" height="200"></canvas>
+      </div>
+      <div id="goal-panel">
+        <div id="goal-toggle">
+          <button data-mode="daily" class="active">Daily</button>
+          <button data-mode="weekly">Weekly</button>
+        </div>
+        <div id="goal-list"></div>
+      </div>
+    </div>
   </section>
 
   <script src="script.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -84,3 +84,84 @@ section { margin-bottom: 30px; }
   background: yellow;
   transition: background-color 0.5s;
 }
+
+/* chart and goal panel layout */
+#chart-goal-container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+#chart-container {
+  flex: 0 0 60%;
+}
+
+#goal-panel {
+  flex: 0 0 40%;
+  border: 1px solid #ccc;
+  padding: 10px;
+  box-sizing: border-box;
+}
+
+#goal-panel #goal-toggle {
+  margin-bottom: 10px;
+}
+
+#goal-panel #goal-toggle button {
+  margin-right: 5px;
+}
+
+#goal-panel #goal-toggle button.active {
+  font-weight: bold;
+}
+
+#goal-list .goal-item {
+  display: flex;
+  align-items: center;
+  margin-bottom: 6px;
+  gap: 6px;
+}
+
+#goal-list .goal-item span.goal-cat {
+  flex: 1;
+}
+
+#goal-list .goal-item input {
+  width: 60px;
+}
+
+#goal-list .progress {
+  flex: 1;
+  height: 10px;
+  background: #eee;
+  position: relative;
+}
+
+#goal-list .progress span {
+  display: block;
+  height: 100%;
+  width: 0;
+}
+
+#goal-list .progress.met span {
+  background: #4caf50;
+}
+
+#goal-list .progress.close span {
+  background: #ffeb3b;
+}
+
+#goal-list .progress.missed span {
+  background: #f44336;
+}
+
+#chart {
+  max-width: 400px;
+}
+
+@media (max-width: 600px) {
+  #chart-container,
+  #goal-panel {
+    flex: 0 0 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- add master category list and store in localStorage
- add goal panel with daily/weekly toggle
- track and display progress for each category
- show all categories in weekly overview and goal panel
- layout chart and goal panel side by side and responsive

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6887bfb4c83c8322b02e489a5efe6402