### PR TITLE
Improve weekly heatmap and chart layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
     <button id="show-chart">Show Chart</button>
 <div id="chart-goal-container">
   <div id="chart-container">
-    <canvas id="chart" width="400" height="200"></canvas>
+    <canvas id="chart"></canvas>
   </div>
   <div id="goal-panel">
     <div id="goal-toggle">

--- a/script.js
+++ b/script.js
@@ -29,6 +29,11 @@
   let categoryList = JSON.parse(localStorage.getItem('categoryList') || '[]');
   let goals = JSON.parse(localStorage.getItem('goals') || '{"daily":{},"weekly":{}}');
 
+  // ensure category list includes all categories found in saved entries
+  const allCategories = [...new Set(entries.map(e => e.category))];
+  const merged = new Set(categoryList.concat(allCategories));
+  categoryList = Array.from(merged);
+
   function saveColors() {
     localStorage.setItem('categoryColors', JSON.stringify(categoryColors));
   }

--- a/styles.css
+++ b/styles.css
@@ -106,14 +106,17 @@ canvas {
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
+  align-items: flex-start;
 }
 
 #chart-container {
-  flex: 0 0 60%;
+  flex: 1 1 60%;
+  min-width: 250px;
 }
 
 #goal-panel {
-  flex: 0 0 40%;
+  flex: 1 1 35%;
+  min-width: 200px;
   border: 1px solid #ccc;
   padding: 10px;
   box-sizing: border-box;
@@ -172,7 +175,7 @@ canvas {
 }
 
 #chart {
-  max-width: 400px;
+  max-width: 100%;
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- ensure category list always includes categories from saved entries
- remove fixed width/height from chart canvas
- update chart/goal layout with flexbox improvements
- expand chart to fill available width

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6887d19159248322842417c490a8cc73