### PR TITLE
Adjust goal input sizing

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -146,7 +146,8 @@ canvas {
 }
 
 #goal-list .goal-item input {
-  width: 60px;
+  flex: 0.2;
+  min-width: 60px;
 }
 
 #goal-list .progress {


### PR DESCRIPTION
## Summary
- adjust goal input width so it grows relative to category label

## Testing
- `npm test` *(fails: `package.json` missing)*

------
https://chatgpt.com/codex/tasks/task_e_6887d6fc9af88322b5414309606ec020