### PR TITLE
Remove unnecessary saves after Firestore load

### DIFF
--- a/script.js
+++ b/script.js
@@ -820,10 +820,6 @@ signupBtn.addEventListener("click", () => {
         categoryList = [];
         goals = {daily:{},weekly:{}};
       }
-      saveEntries();
-      saveColors();
-      saveCategoryList();
-      saveGoals();
       sections.forEach(s => s.classList.remove('hidden'));
       renderView();
     } else {


### PR DESCRIPTION
## Summary
- clean up auth state logic
- stop re-saving empty data after loading from Firestore

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6888df3e4d408322a60c5ca4beae7266