### PR TITLE
Fix login render timing

### DIFF
--- a/script.js
+++ b/script.js
@@ -603,8 +603,7 @@
     console.log('Goal panel rendered');
   }
 
-  // initial render
-  renderView();
+
 
   form.addEventListener('submit', e => {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- remove initial call to `renderView()`
- ensure sections become visible and view is rendered only after login data loads

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6888e2228c048322802f2677c6306e74