### PR TITLE
Fix local storage usage after sync

### DIFF
--- a/script.js
+++ b/script.js
@@ -753,6 +753,7 @@
   });
 
   window.addEventListener('storage', () => {
+    if (auth.currentUser) return;
     entries = JSON.parse(localStorage.getItem('entries') || '[]');
     categoryColors = JSON.parse(localStorage.getItem('categoryColors') || '{}');
     renderCategoryOverview();
@@ -775,7 +776,12 @@ signupBtn.addEventListener("click", () => {
     }
   });
   logoutBtn.addEventListener("click", () => {
-    auth.signOut();
+    auth.signOut().then(() => {
+      localStorage.removeItem('entries');
+      localStorage.removeItem('categoryColors');
+      localStorage.removeItem('categoryList');
+      localStorage.removeItem('goals');
+    });
   });
 
   function showAppUI(email) {
@@ -849,6 +855,7 @@ signupBtn.addEventListener("click", () => {
       localStorage.removeItem('categoryColors');
       localStorage.removeItem('categoryList');
       localStorage.removeItem('goals');
+      localStorage.setItem('syncedOnce', 'true');
 
       console.log(`Synced ${entries.length} entries and ${categoryList.length} categories`);
 


### PR DESCRIPTION
## Summary
- ignore storage events when logged in
- clear local data after sign out
- mark device as synced when pulling from cloud

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6888ff9eddb883228352a991b6927e10