### PR TITLE
Enable editing of categories in weekly overview

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -102,6 +102,15 @@ canvas {
   transition: background-color 0.5s;
 }
 
+.color-swatch {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  margin-right: 4px;
+  vertical-align: middle;
+}
+
 /* chart and goal panel layout */
 #chart-goal-container {
   display: flex;


### PR DESCRIPTION
## Summary
- show colour swatch with category name in weekly table
- allow editing a category's name and colour from the table

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68890d0ceb1083229efcfdb783627924