### PR TITLE
Add weekly/monthly goal panel styles

### DIFF
--- a/script.js
+++ b/script.js
@@ -695,6 +695,7 @@
   }
 
   function renderGoalPanel() {
+    document.getElementById("goal-panel").className = "goal-panel " + goalMode;
     goalListEl.innerHTML = '';
     categoryList.forEach(cat => {
       const item = document.createElement('div');

--- a/styles.css
+++ b/styles.css
@@ -133,6 +133,14 @@ canvas {
   box-sizing: border-box;
 }
 
+/* Visual style based on goal mode */
+.goal-panel.weekly {
+  border-left: 4px solid #2d8cf0;
+}
+.goal-panel.monthly {
+  border-left: 4px solid #f39c12;
+}
+
 #goal-panel #goal-toggle {
   margin-bottom: 10px;
 }


### PR DESCRIPTION
## Summary
- style goal panel differently for weekly vs monthly goals
- switch goal panel classes when rendering goals

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6889154010088322bffeb627a0541e81