### PR TITLE
Improve goal panel input handling

### DIFF
--- a/script.js
+++ b/script.js
@@ -709,14 +709,24 @@
       input.type = 'number';
       input.step = '0.1';
       input.placeholder = 'Set Goal';
-      input.value = goals[goalMode][cat] !== undefined ? goals[goalMode][cat] : '';
-      input.addEventListener('change', () => {
-        const val = parseFloat(input.value);
-        if (isNaN(val)) {
-          delete goals[goalMode][cat];
+      let originalVal = goals[goalMode][cat] ?? '';
+      input.value = originalVal;
+
+      input.addEventListener('input', () => {
+        input.dataset.dirty = 'true';
+      });
+
+      input.addEventListener('blur', () => {
+        if (input.dataset.dirty !== 'true') return;
+
+        const newVal = parseFloat(input.value);
+        if (!isNaN(newVal)) {
+          goals[goalMode][cat] = newVal;
         } else {
-          goals[goalMode][cat] = val;
+          delete goals[goalMode][cat];
         }
+
+        delete input.dataset.dirty;
         saveGoals();
         renderGoalPanel();
       });


### PR DESCRIPTION
## Summary
- revise goal update events in `renderGoalPanel()`
  - store original value for each goal input
  - mark input dirty on edit and update goals on blur

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_68891a81a7208322a0247b86d49ee40a