### PR TITLE
Ensure goal panel shows categories in month view

### DIFF
--- a/script.js
+++ b/script.js
@@ -697,8 +697,30 @@ let goalMode = 'weekly';
     goalListEl.innerHTML = '';
     const mode = getGoalMode();
     const key = getGoalKey(mode);
+
+    const categorySet = new Set();
+    entries.forEach(e => {
+      const eDate = new Date(e.date);
+      if (mode === 'weekly') {
+        const start = new Date(currentWeekStart);
+        const end = new Date(start);
+        end.setDate(end.getDate() + 6);
+        if (eDate >= start && eDate <= end) categorySet.add(e.category);
+      } else {
+        const start = new Date(currentMonthStart);
+        const end = new Date(start.getFullYear(), start.getMonth() + 1, 0);
+        if (eDate >= start && eDate <= end) categorySet.add(e.category);
+      }
+    });
+
+    const categories = Array.from(categorySet).sort();
+
     const currentGoals = goals[mode][key] || {};
-    categoryList.forEach(cat => {
+
+    console.log('Current goal mode:', getGoalMode(), 'Goal key:', getGoalKey());
+    console.log('Visible categories:', categories);
+
+    categories.forEach(cat => {
       const item = document.createElement('div');
       item.className = 'goal-item';
       const nameSpan = document.createElement('span');


### PR DESCRIPTION
## Summary
- show goals for categories that appear in the visible range
- log current goal mode and visible categories for debugging

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_688925ba6a908322a68f390a0e3c1d37