### PR TITLE
Fix goal panel categories

### DIFF
--- a/script.js
+++ b/script.js
@@ -699,6 +699,12 @@ let goalMode = 'weekly';
     const key = getGoalKey(mode);
 
     const categorySet = new Set();
+
+    // Include categories from saved goals for this period
+    const savedGoals = goals[mode][key] || {};
+    Object.keys(savedGoals).forEach(cat => categorySet.add(cat));
+
+    // Also include categories found in entries within the current period
     entries.forEach(e => {
       const eDate = new Date(e.date);
       if (mode === 'weekly') {


### PR DESCRIPTION
## Summary
- show saved goals in weekly/monthly panel even without entries

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688928699f548322a54eaf5eec9c0671